### PR TITLE
[totoro/#4] 2주차 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.storage.CacheResetOnProcessCanceled.enabled
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".song.SongActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.Umc_7th">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/umc/study/umc_7th/BottomNavigationBar.kt
+++ b/app/src/main/java/umc/study/umc_7th/BottomNavigationBar.kt
@@ -23,8 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -219,7 +217,7 @@ fun PreviewBottomNavigationBar() {
         currentContent = Content(
             title = "사랑하긴 했었나요 스쳐가는 인연이었나요 짧지않은 우리 함께했던 시간들이 자꾸 내 마음을 가둬두네",
             author = "잔나비",
-            image = ImageBitmap.imageResource(id = R.drawable.img_album_exp),
+            imageId = R.drawable.img_album_exp,
             length = 200,
         ),
         isPlaying = true,

--- a/app/src/main/java/umc/study/umc_7th/BottomNavigationBar.kt
+++ b/app/src/main/java/umc/study/umc_7th/BottomNavigationBar.kt
@@ -1,5 +1,7 @@
 package umc.study.umc_7th
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -209,17 +211,13 @@ fun BottomNavigationBar(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun PreviewBottomNavigationBar() {
     BottomNavigationBar(
         currentDestination = NavigationDestination.HOME,
-        currentContent = Content(
-            title = "사랑하긴 했었나요 스쳐가는 인연이었나요 짧지않은 우리 함께했던 시간들이 자꾸 내 마음을 가둬두네",
-            author = "잔나비",
-            imageId = R.drawable.img_album_exp,
-            length = 200,
-        ),
+        currentContent = getTestMusicContentList((1..4).random()).random(),
         isPlaying = true,
         onDestinationClicked = {},
         onPlayButtonClicked = {},

--- a/app/src/main/java/umc/study/umc_7th/Content.kt
+++ b/app/src/main/java/umc/study/umc_7th/Content.kt
@@ -1,35 +1,173 @@
 package umc.study.umc_7th
 
+import android.os.Build
+import androidx.annotation.IntRange
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
 import java.io.Serializable
+import java.time.LocalDate
 
-data class Content(
-    val title: String,
-    val author: String,
-    val imageId: Int,
-    val length: Int,  // 단위: 초
+sealed class Content(
+    open val title: String,
+    open val author: String,
+    open val imageId: Int,
+    open val length: Int,  // 단위: 초
 ): Serializable {
     val imageBitmap: ImageBitmap @Composable get() = ImageLoader.getImageBitmap(id = imageId)
 }
 
+data class Album(
+    val title: String,
+    val author: String,
+    val imageId: Int,
+    val type: String,
+    val genre: String,
+    val releasedDate: LocalDate,
+): Serializable {
+    val imageBitmap: ImageBitmap @Composable get() = ImageLoader.getImageBitmap(id = imageId)
+}
+
+data class MusicContent(
+    override val title: String,
+    override val author: String,
+    override val imageId: Int,
+    override val length: Int,  // 단위: 초
+    val album: Album,
+): Content(
+    title = title,
+    author = author,
+    imageId = imageId,
+    length = length,
+), Serializable
+
+data class PodcastContent(
+    override val title: String,
+    override val author: String,
+    override val imageId: Int,
+    override val length: Int,  // 단위: 초
+): Content(
+    title = title,
+    author = author,
+    imageId = imageId,
+    length = length,
+), Serializable
+
+data class VideoContent(
+    override val title: String,
+    override val author: String,
+    override val imageId: Int,
+    override val length: Int,  // 단위: 초
+): Content(
+    title = title,
+    author = author,
+    imageId = imageId,
+    length = length,
+), Serializable
+
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun getTestContentList(): List<Content> = listOf(
-    "라일락",
-    "Flu",
-    "Coin",
-    "봄 안녕 봄",
-    "Celebrity",
-    "돌림노래 (feat. DEAN)",
-    "빈 컵 (Empty Cup)",
-    "아이와 나의 바다",
-    "어푸 (Ah puh)",
-    "에필로그",
-).map {
-    Content(
-        title = it,
+fun getTestMusicContentList(
+    @IntRange(from = 1, to = 4) number: Int
+): List<MusicContent> = when (number) {
+    1 -> Album(
+        title = "IU 5th Album \"LILAC\"",
         author = "아이유(IU)",
         imageId = R.drawable.img_album_exp2,
-        length = 210,
-    )
+        type = "정규",
+        genre = "댄스 팝",
+        releasedDate = LocalDate.parse("2021-03-25"),
+    ).run {
+        listOf(
+            "라일락",
+            "Flu",
+            "Coin",
+            "봄 안녕 봄",
+            "Celebrity",
+            "돌림노래 (feat. DEAN)",
+            "빈 컵 (Empty Cup)",
+            "아이와 나의 바다",
+            "어푸 (Ah puh)",
+            "에필로그",
+        ).map {
+            MusicContent(
+                title = it,
+                author = "아이유(IU)",
+                imageId = R.drawable.img_album_exp2,
+                length = 210,
+                album = this@run,
+            )
+        }
+    }
+
+    2 -> Album(
+        title = "Butter (feat. Megan Thee Stallion)",
+        author = "BTS",
+        imageId = R.drawable.img_album_exp,
+        type = "싱글",
+        genre = "댄스 팝",
+        releasedDate = LocalDate.parse("2021-05-21"),
+    ).run {
+        listOf(
+            "Butter",
+        ).map {
+            MusicContent(
+                title = it,
+                author = "BTS",
+                imageId = R.drawable.img_album_exp,
+                length = 210,
+                album = this@run,
+            )
+        }
+    }
+
+    3 -> Album(
+        title = "Next Level",
+        author = "aespa",
+        imageId = R.drawable.img_album_exp3,
+        type = "싱글",
+        genre = "댄스 팝",
+        releasedDate = LocalDate.parse("2021-05-17"),
+    ).run {
+        listOf(
+            "Next Level",
+        ).map {
+            MusicContent(
+                title = it,
+                author = "aespa",
+                imageId = R.drawable.img_album_exp3,
+                length = 210,
+                album = this@run,
+            )
+        }
+    }
+
+    4 -> Album(
+        title = "MAP OF THE SOUL : PERSONA",
+        author = "BTS",
+        imageId = R.drawable.img_album_exp4,
+        type = "미니",
+        genre = "댄스 팝",
+        releasedDate = LocalDate.parse("2019-04-12"),
+    ).run {
+        listOf(
+            "Intro : Persona",
+            "작은 것들을 위한 시 (Boy With Luv) (Feat. Halsey)",
+            "소우주 (Mikrokosmos)",
+            "Make It Right",
+            "HOME",
+            "Jamais Vu",
+            "Dionysus",
+        ).map {
+            MusicContent(
+                title = it,
+                author = "BTS",
+                imageId = R.drawable.img_album_exp4,
+                length = 210,
+                album = this@run,
+            )
+        }
+    }
+
+    else -> throw IllegalArgumentException()
 }

--- a/app/src/main/java/umc/study/umc_7th/Content.kt
+++ b/app/src/main/java/umc/study/umc_7th/Content.kt
@@ -24,6 +24,7 @@ data class Album(
     val type: String,
     val genre: String,
     val releasedDate: LocalDate,
+    val contentList: MutableList<Pair<MusicContent, String?>>,
 ): Serializable {
     val imageBitmap: ImageBitmap @Composable get() = ImageLoader.getImageBitmap(id = imageId)
 }
@@ -77,6 +78,7 @@ fun getTestMusicContentList(
         type = "정규",
         genre = "댄스 팝",
         releasedDate = LocalDate.parse("2021-03-25"),
+        contentList = mutableListOf()
     ).run {
         listOf(
             "라일락",
@@ -89,14 +91,16 @@ fun getTestMusicContentList(
             "아이와 나의 바다",
             "어푸 (Ah puh)",
             "에필로그",
-        ).map {
-            MusicContent(
-                title = it,
+        ).mapIndexed { index, title ->
+            val content = MusicContent(
+                title = title,
                 author = "아이유(IU)",
                 imageId = R.drawable.img_album_exp2,
                 length = 210,
-                album = this@run,
+                album = this,
             )
+            this.contentList.add(content to if (index == 0 || index == 2) "TITLE" else null)
+            content
         }
     }
 
@@ -107,17 +111,20 @@ fun getTestMusicContentList(
         type = "싱글",
         genre = "댄스 팝",
         releasedDate = LocalDate.parse("2021-05-21"),
+        contentList = mutableListOf()
     ).run {
         listOf(
             "Butter",
         ).map {
-            MusicContent(
+            val content = MusicContent(
                 title = it,
                 author = "BTS",
                 imageId = R.drawable.img_album_exp,
                 length = 210,
-                album = this@run,
+                album = this,
             )
+            this.contentList.add(content to "SINGLE")
+            content
         }
     }
 
@@ -128,17 +135,20 @@ fun getTestMusicContentList(
         type = "싱글",
         genre = "댄스 팝",
         releasedDate = LocalDate.parse("2021-05-17"),
+        contentList = mutableListOf()
     ).run {
         listOf(
             "Next Level",
         ).map {
-            MusicContent(
+            val content = MusicContent(
                 title = it,
                 author = "aespa",
                 imageId = R.drawable.img_album_exp3,
                 length = 210,
-                album = this@run,
+                album = this,
             )
+            this.contentList.add(content to "SINGLE")
+            content
         }
     }
 
@@ -149,6 +159,7 @@ fun getTestMusicContentList(
         type = "미니",
         genre = "댄스 팝",
         releasedDate = LocalDate.parse("2019-04-12"),
+        contentList = mutableListOf()
     ).run {
         listOf(
             "Intro : Persona",
@@ -158,14 +169,16 @@ fun getTestMusicContentList(
             "HOME",
             "Jamais Vu",
             "Dionysus",
-        ).map {
-            MusicContent(
-                title = it,
+        ).mapIndexed { index, title ->
+            val content = MusicContent(
+                title = title,
                 author = "BTS",
                 imageId = R.drawable.img_album_exp4,
                 length = 210,
-                album = this@run,
+                album = this,
             )
+            this.contentList.add(content to if (index == 1) "TITLE" else null)
+            content
         }
     }
 

--- a/app/src/main/java/umc/study/umc_7th/Content.kt
+++ b/app/src/main/java/umc/study/umc_7th/Content.kt
@@ -1,10 +1,35 @@
 package umc.study.umc_7th
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
+import java.io.Serializable
 
 data class Content(
     val title: String,
     val author: String,
-    val image: ImageBitmap,
+    val imageId: Int,
     val length: Int,  // 단위: 초
-)
+): Serializable {
+    val imageBitmap: ImageBitmap @Composable get() = ImageLoader.getImageBitmap(id = imageId)
+}
+
+@Composable
+fun getTestContentList(): List<Content> = listOf(
+    "라일락",
+    "Flu",
+    "Coin",
+    "봄 안녕 봄",
+    "Celebrity",
+    "돌림노래 (feat. DEAN)",
+    "빈 컵 (Empty Cup)",
+    "아이와 나의 바다",
+    "어푸 (Ah puh)",
+    "에필로그",
+).map {
+    Content(
+        title = it,
+        author = "아이유(IU)",
+        imageId = R.drawable.img_album_exp2,
+        length = 210,
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/ImageLoader.kt
+++ b/app/src/main/java/umc/study/umc_7th/ImageLoader.kt
@@ -1,0 +1,24 @@
+package umc.study.umc_7th
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.res.imageResource
+
+object ImageLoader {
+    private var idSequence = 0
+        get() = --field
+    private val imageMap = emptyMap<Int, ImageBitmap>().toMutableMap()
+
+    @Composable
+    fun getImageBitmap(id: Int): ImageBitmap {
+        if (!imageMap.containsKey(id) && id > 0)
+            imageMap[id] = ImageBitmap.imageResource(id = id)
+        return imageMap[id]!!
+    }
+
+    fun putImageBitmap(image: ImageBitmap): Int {
+        val id = idSequence
+        imageMap[id] = image
+        return id
+    }
+}

--- a/app/src/main/java/umc/study/umc_7th/MainActivity.kt
+++ b/app/src/main/java/umc/study/umc_7th/MainActivity.kt
@@ -1,10 +1,11 @@
 package umc.study.umc_7th
 
+import android.content.Intent
 import android.os.Bundle
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.imageResource
 import androidx.fragment.app.FragmentActivity
+import umc.study.umc_7th.home.HomeFragment
+import umc.study.umc_7th.song.SongActivity
 
 class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,12 +25,16 @@ class MainActivity : FragmentActivity() {
                 currentContent = Content(
                     title = "Butter",
                     author = "BTS",
-                    image = ImageBitmap.imageResource(id = R.drawable.img_album_exp),
+                    imageId = R.drawable.img_album_exp,
                     length = 200,
                 ),
                 isPlaying = false,
                 onDestinationClicked = { /*TODO*/ },
-                onContentClicked = { /*TODO*/ },
+                onContentClicked = { content ->
+                    val intent = Intent(this, SongActivity::class.java)
+                    intent.putExtra("content", content)
+                    startActivity(intent)
+                },
                 onPlayButtonClicked = { /*TODO*/ },
                 onNextButtonClicked = { /*TODO*/ },
                 onPreviousButtonClicked = { /*TODO*/ }) {

--- a/app/src/main/java/umc/study/umc_7th/MainActivity.kt
+++ b/app/src/main/java/umc/study/umc_7th/MainActivity.kt
@@ -1,13 +1,16 @@
 package umc.study.umc_7th
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.FragmentActivity
 import umc.study.umc_7th.home.HomeFragment
 import umc.study.umc_7th.song.SongActivity
 
 class MainActivity : FragmentActivity() {
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -22,12 +25,7 @@ class MainActivity : FragmentActivity() {
         composeViewMain.setContent {
             BottomNavigationBar(
                 currentDestination = NavigationDestination.HOME,
-                currentContent = Content(
-                    title = "Butter",
-                    author = "BTS",
-                    imageId = R.drawable.img_album_exp,
-                    length = 200,
-                ),
+                currentContent = getTestMusicContentList((1..4).random()).random(),
                 isPlaying = false,
                 onDestinationClicked = { /*TODO*/ },
                 onContentClicked = { content ->

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumDetailsPage.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumDetailsPage.kt
@@ -1,0 +1,8 @@
+package umc.study.umc_7th.album
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun AlbumDetailsPage() {
+    // TODO: 구현
+}

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumFragment.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumFragment.kt
@@ -15,18 +15,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
+import umc.study.umc_7th.Album
 import umc.study.umc_7th.BottomNavigationBar
-import umc.study.umc_7th.Content
 import umc.study.umc_7th.NavigationDestination
 import umc.study.umc_7th.R
-import umc.study.umc_7th.getTestContentList
-import java.time.LocalDate
+import umc.study.umc_7th.getTestMusicContentList
 
 class AlbumFragment : Fragment() {
     @RequiresApi(Build.VERSION_CODES.O)
@@ -35,9 +32,15 @@ class AlbumFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        val album = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            arguments?.getSerializable("album", Album::class.java)!!
+        else
+            arguments?.getSerializable("album")!! as Album
+
         return inflater.inflate(R.layout.fragment_album, container, false).apply {
             findViewById<ComposeView>(R.id.composeView_album).setContent {
                 AlbumScreen(
+                    album = album,
                     onBackButtonClicked = {
                         activity?.supportFragmentManager?.beginTransaction()
                             ?.remove(this@AlbumFragment)
@@ -53,6 +56,7 @@ class AlbumFragment : Fragment() {
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun AlbumScreen(
+    album: Album,
     onBackButtonClicked: () -> Unit,
 ) {
     // 이 화면은 목업입니다.
@@ -67,12 +71,12 @@ private fun AlbumScreen(
             onDetailsButtonClicked = {}
         )
         AlbumFrame(
-            title = "IU 5th Album \"LILAC\"",
-            author = "아이유(IU)",
-            cover = ImageBitmap.imageResource(id = R.drawable.img_album_exp2),
-            releasedDate = LocalDate.parse("2021-03-25"),
-            type = "정규",
-            genre = "댄스 팝",
+            title = album.title,
+            author = album.author,
+            cover = album.imageBitmap,
+            releasedDate = album.releasedDate,
+            type = album.type,
+            genre = album.genre,
         )
         TabLayout(
             tabs = listOf(
@@ -80,10 +84,10 @@ private fun AlbumScreen(
                     label = "수록곡",
                     page = {
                         IncludedContentsPage(
-                            contentList = getTestContentList().mapIndexed { index, content ->
-                                ContentWithTitleLabel(
-                                    content = content,
-                                    isTitle = index == 0,
+                            contentList = album.contentList.map {
+                                ContentWithLabel(
+                                    content = it.first,
+                                    label = it.second,
                                 )
                             },
                             isMixed = false,
@@ -125,18 +129,14 @@ fun PreviewAlbumScreen() {
                 onPlayButtonClicked = {},
                 onContentClicked = {},
                 currentDestination = NavigationDestination.HOME,
-                currentContent = Content(
-                    title = "Butter",
-                    author = "BTS",
-                    imageId = R.drawable.img_album_exp,
-                    length = 200,
-                ),
+                currentContent = getTestMusicContentList((1..4).random()).random(),
                 isPlaying = false,
             )
         }
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             AlbumScreen(
+                album = getTestMusicContentList((1..4).random()).random().album,
                 onBackButtonClicked = {}
             )
         }

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumFragment.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumFragment.kt
@@ -1,0 +1,142 @@
+package umc.study.umc_7th.album
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.imageResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import umc.study.umc_7th.BottomNavigationBar
+import umc.study.umc_7th.Content
+import umc.study.umc_7th.NavigationDestination
+import umc.study.umc_7th.R
+import umc.study.umc_7th.getTestContentList
+import java.time.LocalDate
+
+class AlbumFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_album, container, false).apply {
+            findViewById<ComposeView>(R.id.composeView_album).setContent {
+                AlbumScreen(
+                    onBackButtonClicked = {
+                        activity?.supportFragmentManager?.beginTransaction()
+                            ?.remove(this@AlbumFragment)
+                            ?.commit()
+                        activity?.supportFragmentManager?.popBackStack()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumScreen(
+    onBackButtonClicked: () -> Unit,
+) {
+    // 이 화면은 목업입니다.
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.verticalScroll(rememberScrollState())
+    ) {
+        TopButtonBar(
+            isLiked = false,
+            onBackButtonClicked = onBackButtonClicked,
+            onLikeButtonClicked = {},
+            onDetailsButtonClicked = {}
+        )
+        AlbumFrame(
+            title = "IU 5th Album \"LILAC\"",
+            author = "아이유(IU)",
+            cover = ImageBitmap.imageResource(id = R.drawable.img_album_exp2),
+            releasedDate = LocalDate.parse("2021-03-25"),
+            type = "정규",
+            genre = "댄스 팝",
+        )
+        TabLayout(
+            tabs = listOf(
+                TabItem(
+                    label = "수록곡",
+                    page = {
+                        IncludedContentsPage(
+                            contentList = getTestContentList().mapIndexed { index, content ->
+                                ContentWithTitleLabel(
+                                    content = content,
+                                    isTitle = index == 0,
+                                )
+                            },
+                            isMixed = false,
+                            onPlayContentClicked = {},
+                            onContentDetailsClicked = {},
+                            onMixButtonClicked = {},
+                            onPlayAllButtonClicked = {},
+                        )
+                    },
+                ),
+                TabItem(
+                    label = "상세정보",
+                    page = {
+                        AlbumDetailsPage()
+                    },
+                ),
+                TabItem(
+                    label = "영상",
+                    page = {
+                        VideosPage()
+                    },
+                ),
+            )
+        )
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun PreviewAlbumScreen() {
+    Scaffold(
+        bottomBar = {
+            BottomNavigationBar(
+                onPlaylistButtonClicked = {},
+                onDestinationClicked = {},
+                onPreviousButtonClicked = {},
+                onNextButtonClicked = {},
+                onPlayButtonClicked = {},
+                onContentClicked = {},
+                currentDestination = NavigationDestination.HOME,
+                currentContent = Content(
+                    title = "Butter",
+                    author = "BTS",
+                    imageId = R.drawable.img_album_exp,
+                    length = 200,
+                ),
+                isPlaying = false,
+            )
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            AlbumScreen(
+                onBackButtonClicked = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumFragment.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumFragment.kt
@@ -29,6 +29,7 @@ import umc.study.umc_7th.getTestContentList
 import java.time.LocalDate
 
 class AlbumFragment : Fragment() {
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -49,6 +50,7 @@ class AlbumFragment : Fragment() {
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun AlbumScreen(
     onBackButtonClicked: () -> Unit,

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumFrame.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumFrame.kt
@@ -1,0 +1,136 @@
+package umc.study.umc_7th.album
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.imageResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import umc.study.umc_7th.R
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun AlbumFrame(
+    title: String,
+    author: String,
+    cover: ImageBitmap,
+    releasedDate: LocalDate,
+    type: String,
+    genre: String,
+) {
+    var coverWidth by remember { mutableStateOf(0.dp) }
+    var coverSideWidth by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
+    
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .padding(4.dp)
+            .fillMaxWidth()
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = title,
+                style = TextStyle(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp
+                ),
+            )
+            Text(
+                text = author,
+                style = TextStyle(
+                    color = Color.Black.copy(alpha = 0.5f),
+                ),
+            )
+            Text(
+                text = "${
+                    DateTimeFormatter.ofPattern("yyyy.MM.dd").format(releasedDate)
+                } | $type | $genre",
+                style = TextStyle(
+                    color = Color.Black.copy(alpha = 0.5f),
+                ),
+            )
+        }
+        Box(
+            contentAlignment = Alignment.Center,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Spacer(
+                    modifier = Modifier
+                        .let { if (coverWidth.value > 0) it.animateContentSize() else it }
+                        .width(coverSideWidth.plus(coverWidth))
+                )
+                Image(
+                    painter = painterResource(id = R.drawable.img_album_lp),
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .height(coverWidth.times(0.9f))
+                        .onGloballyPositioned {
+                            with(density) { coverSideWidth = it.size.width.toDp() }
+                        },
+                    contentDescription = null,
+                )
+            }
+            Image(
+                bitmap = cover,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth(0.6f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .onGloballyPositioned {
+                        with(density) { coverWidth = it.size.width.toDp() }
+                    },
+                contentDescription = null,
+            )
+
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAlbumFrame() {
+    AlbumFrame(
+        title = "IU 5th Album \"LILAC\"",
+        author = "아이유(IU)",
+        cover = ImageBitmap.imageResource(id = R.drawable.img_album_exp2),
+        releasedDate = LocalDate.parse("2021-03-25"),
+        type = "정규",
+        genre = "댄스 팝",
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumFrame.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumFrame.kt
@@ -1,5 +1,7 @@
 package umc.study.umc_7th.album
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +39,7 @@ import umc.study.umc_7th.R
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AlbumFrame(
     title: String,
@@ -121,6 +124,7 @@ fun AlbumFrame(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun PreviewAlbumFrame() {

--- a/app/src/main/java/umc/study/umc_7th/album/AlbumFrame.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/AlbumFrame.kt
@@ -1,7 +1,6 @@
 package umc.study.umc_7th.album
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.animate
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/umc/study/umc_7th/album/IncludedContentsPage.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/IncludedContentsPage.kt
@@ -1,5 +1,7 @@
 package umc.study.umc_7th.album
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -36,7 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import umc.study.umc_7th.Content
 import umc.study.umc_7th.R
-import umc.study.umc_7th.getTestContentList
+import umc.study.umc_7th.getTestMusicContentList
 
 data class ContentWithTitleLabel(
     val content: Content,
@@ -275,11 +277,12 @@ fun IncludedContentsPage(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun PreviewIncludedContentsPage() {
     IncludedContentsPage(
-        contentList = getTestContentList().mapIndexed { index, content ->
+        contentList = getTestMusicContentList((1..4).random()).mapIndexed { index, content ->
             ContentWithTitleLabel(
                 content = content,
                 isTitle = index == 0,

--- a/app/src/main/java/umc/study/umc_7th/album/IncludedContentsPage.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/IncludedContentsPage.kt
@@ -1,0 +1,294 @@
+package umc.study.umc_7th.album
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import umc.study.umc_7th.Content
+import umc.study.umc_7th.R
+import umc.study.umc_7th.getTestContentList
+
+data class ContentWithTitleLabel(
+    val content: Content,
+    val isTitle: Boolean,
+)
+
+@Composable
+fun IncludedContentsPage(
+    contentList: List<ContentWithTitleLabel>,
+    isMixed: Boolean,
+    onPlayContentClicked: (Content) -> Unit,
+    onContentDetailsClicked: (Content) -> Unit,
+    onMixButtonClicked: (Boolean) -> Unit,
+    onPlayAllButtonClicked: () -> Unit,
+) {
+    val isContentSelected = remember(contentList) {
+        List(contentList.size) { false }.toMutableStateList()
+    }
+
+    Column {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.padding(8.dp),
+        ) {
+            // 내 취향 MIX
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .background(
+                        color = Color.Black.copy(alpha = 0.05f),
+                        shape = RoundedCornerShape(percent = 50)
+                    )
+                    .padding(8.dp)
+            ) {
+                Text(
+                    text = "내 취향 MIX",
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+                IconButton(
+                    onClick = { onMixButtonClicked(!isMixed) },
+                    modifier = Modifier.height(16.dp)
+                ) {
+                    Image(
+                        painter = painterResource(
+                            id = if (isMixed)
+                                R.drawable.btn_toggle_on
+                            else
+                                R.drawable.btn_toggle_off
+                        ),
+                        contentDescription = null,
+                        modifier = Modifier.height(32.dp),
+                        contentScale = ContentScale.Crop,
+                    )
+                }
+            }
+            // 전체선택과 전체듣기
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .fillMaxWidth()
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(percent = 50))
+                        .clickable {
+                            if (isContentSelected.contains(true))
+                                repeat(isContentSelected.size) { isContentSelected[it] = false }
+                            else
+                                repeat(isContentSelected.size) { isContentSelected[it] = true }
+                        }
+                ) {
+                    Image(
+                        painter = painterResource(
+                            id = if (!isContentSelected.contains(false))
+                                R.drawable.btn_playlist_select_on
+                            else
+                                R.drawable.btn_playlist_select_off
+                        ),
+                        contentScale = ContentScale.Fit,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Text(
+                        text = "전체선택",
+                        style = TextStyle(
+                            fontSize = 12.sp,
+                            color = if (!isContentSelected.contains(false))
+                                Color.Blue
+                            else
+                                Color.Unspecified
+                        ),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(percent = 50))
+                        .clickable { onPlayAllButtonClicked() }
+                ) {
+                    Icon(
+                        painter = painterResource(
+                            id = R.drawable.btn_editbar_play
+                        ),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Text(
+                        text = "전체듣기",
+                        style = TextStyle(
+                            fontSize = 12.sp,
+                        ),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
+            }
+        }
+        // 목록
+        LazyColumn(
+            modifier = Modifier.heightIn(max = 360.dp)
+        ) {
+            items(
+                count = contentList.size,
+            ) { index ->
+                val (content, isTitle) = contentList[index]
+                Box(
+                    modifier = Modifier
+                        .background(
+                            color = if (isContentSelected[index])
+                                Color.Black.copy(0.1f)
+                            else
+                                Color.Transparent
+                        )
+                        .clickable {
+                            isContentSelected[index] = !isContentSelected[index]
+                        }
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth()
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier
+                                    .width(24.dp)
+                                    .height(24.dp),
+                            ) {
+                                Text(
+                                    text = "%02d".format(index + 1),
+                                    style = TextStyle(
+                                        fontWeight = FontWeight.Bold,
+                                    )
+                                )
+                            }
+                            Column {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.height(24.dp)
+                                ) {
+                                    if (isTitle) Box(
+                                        modifier = Modifier
+                                            .background(
+                                                color = Color.Blue,
+                                                shape = RoundedCornerShape(percent = 50)
+                                            )
+                                            .padding(horizontal = 4.dp, vertical = 1.dp)
+                                    ) {
+                                        Text(
+                                            text = "TITLE",
+                                            style = TextStyle(
+                                                fontSize = 8.sp,
+                                                fontWeight = FontWeight.Bold,
+                                                color = Color.White
+                                            ),
+                                        )
+                                    }
+                                    Text(
+                                        text = content.title,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Clip,
+                                    )
+                                }
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.height(20.dp),
+                                ) {
+                                    Text(
+                                        text = content.author,
+                                        style = TextStyle(
+                                            color = Color.Black.copy(0.5f),
+                                            fontSize = 12.sp
+                                        ),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Clip,
+                                    )
+                                }
+                            }
+                        }
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            IconButton(
+                                onClick = { onPlayContentClicked(content) },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.btn_player_play),
+                                    contentDescription = null
+                                )
+                            }
+                            IconButton(
+                                onClick = { onContentDetailsClicked(content) },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.btn_player_more),
+                                    contentDescription = null
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewIncludedContentsPage() {
+    IncludedContentsPage(
+        contentList = getTestContentList().mapIndexed { index, content ->
+            ContentWithTitleLabel(
+                content = content,
+                isTitle = index == 0,
+            )
+        },
+        isMixed = false,
+        onPlayContentClicked = {},
+        onContentDetailsClicked = {},
+        onMixButtonClicked = {},
+        onPlayAllButtonClicked = {},
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/album/IncludedContentsPage.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/IncludedContentsPage.kt
@@ -40,14 +40,14 @@ import umc.study.umc_7th.Content
 import umc.study.umc_7th.R
 import umc.study.umc_7th.getTestMusicContentList
 
-data class ContentWithTitleLabel(
+data class ContentWithLabel(
     val content: Content,
-    val isTitle: Boolean,
+    val label: String?,
 )
 
 @Composable
 fun IncludedContentsPage(
-    contentList: List<ContentWithTitleLabel>,
+    contentList: List<ContentWithLabel>,
     isMixed: Boolean,
     onPlayContentClicked: (Content) -> Unit,
     onContentDetailsClicked: (Content) -> Unit,
@@ -167,7 +167,7 @@ fun IncludedContentsPage(
             items(
                 count = contentList.size,
             ) { index ->
-                val (content, isTitle) = contentList[index]
+                val (content, label) = contentList[index]
                 Box(
                     modifier = Modifier
                         .background(
@@ -209,22 +209,24 @@ fun IncludedContentsPage(
                                     verticalAlignment = Alignment.CenterVertically,
                                     modifier = Modifier.height(24.dp)
                                 ) {
-                                    if (isTitle) Box(
-                                        modifier = Modifier
-                                            .background(
-                                                color = Color.Blue,
-                                                shape = RoundedCornerShape(percent = 50)
+                                    label?.let {
+                                        Box(
+                                            modifier = Modifier
+                                                .background(
+                                                    color = Color.Blue,
+                                                    shape = RoundedCornerShape(percent = 50)
+                                                )
+                                                .padding(horizontal = 4.dp, vertical = 1.dp)
+                                        ) {
+                                            Text(
+                                                text = label,
+                                                style = TextStyle(
+                                                    fontSize = 8.sp,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = Color.White
+                                                ),
                                             )
-                                            .padding(horizontal = 4.dp, vertical = 1.dp)
-                                    ) {
-                                        Text(
-                                            text = "TITLE",
-                                            style = TextStyle(
-                                                fontSize = 8.sp,
-                                                fontWeight = FontWeight.Bold,
-                                                color = Color.White
-                                            ),
-                                        )
+                                        }
                                     }
                                     Text(
                                         text = content.title,
@@ -282,10 +284,10 @@ fun IncludedContentsPage(
 @Composable
 fun PreviewIncludedContentsPage() {
     IncludedContentsPage(
-        contentList = getTestMusicContentList((1..4).random()).mapIndexed { index, content ->
-            ContentWithTitleLabel(
-                content = content,
-                isTitle = index == 0,
+        contentList = getTestMusicContentList((1..4).random()).random().album.contentList.map {
+            ContentWithLabel(
+                content = it.first,
+                label = it.second,
             )
         },
         isMixed = false,

--- a/app/src/main/java/umc/study/umc_7th/album/TabLayout.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/TabLayout.kt
@@ -1,0 +1,100 @@
+package umc.study.umc_7th.album
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+data class TabItem(
+    val label: String,
+    val page: @Composable () -> Unit,
+)
+
+@Composable
+fun TabLayout(
+    tabs: List<TabItem>,
+) {
+    var currentTabIndex by remember(tabs) { mutableIntStateOf(0) }
+
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            tabs.forEachIndexed { index, (label, _) ->
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .drawBehind {
+                            drawLine(
+                                color = Color.Black.copy(0.1f),
+                                start = Offset(x = 0f, y = size.height),
+                                end = Offset(x = size.width, y = size.height),
+                                strokeWidth = 5f,
+                            )
+                            if (index == currentTabIndex) drawLine(
+                                color = Color.Blue,
+                                start = Offset(x = size.width.times(1 / 3f), y = size.height),
+                                end = Offset(x = size.width.times(2 / 3f), y = size.height),
+                                strokeWidth = 5f,
+                            )
+                        }
+                        .heightIn(min = 48.dp)
+                        .weight(1f)
+                        .clickable { currentTabIndex = index }
+                ) {
+                    Text(
+                        text = label,
+                        style = TextStyle(
+                            color = if (index == currentTabIndex)
+                                Color.Blue
+                            else
+                                Color.Black.copy(alpha = 0.5f),
+                        )
+                    )
+                }
+            }
+        }
+        Box(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            tabs[currentTabIndex].page()
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTabLayout() {
+    TabLayout(
+        tabs = listOf(
+            TabItem(
+                label = "수록곡",
+                page = { Text(text = "이것은 수록곡") },
+            ),
+            TabItem(
+                label = "상세정보",
+                page = { Text(text = "이것은 상세정보") },
+            ),
+            TabItem(
+                label = "영상",
+                page = { Text(text = "이것은 영상") },
+            ),
+        )
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/album/TopButtonBar.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/TopButtonBar.kt
@@ -1,0 +1,79 @@
+package umc.study.umc_7th.album
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import umc.study.umc_7th.R
+
+@Composable
+fun TopButtonBar(
+    isLiked: Boolean,
+    onBackButtonClicked: () -> Unit,
+    onLikeButtonClicked: (Boolean) -> Unit,
+    onDetailsButtonClicked: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+    ) {
+        IconButton(
+            onClick = onBackButtonClicked,
+            modifier = Modifier.size(32.dp),
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.btn_arrow_black),
+                contentDescription = null,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = { onLikeButtonClicked(!isLiked) },
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    painter = painterResource(
+                        id = if (isLiked) R.drawable.ic_my_like_on
+                        else R.drawable.ic_my_like_off
+                    ),
+                    contentDescription = null,
+                )
+            }
+            IconButton(
+                onClick = onDetailsButtonClicked,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.btn_player_more),
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTopButtonBar() {
+    TopButtonBar(
+        isLiked = false,
+        onBackButtonClicked = {},
+        onLikeButtonClicked = {},
+        onDetailsButtonClicked = {}
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/album/VideosPage.kt
+++ b/app/src/main/java/umc/study/umc_7th/album/VideosPage.kt
@@ -1,0 +1,8 @@
+package umc.study.umc_7th.album
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun VideosPage() {
+    // TODO: 구현
+}

--- a/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
@@ -1,8 +1,7 @@
-package umc.study.umc_7th
+package umc.study.umc_7th.home
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
@@ -44,6 +42,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import umc.study.umc_7th.Content
+import umc.study.umc_7th.R
+import umc.study.umc_7th.getTestContentList
 
 enum class GlobeCategory(
     val expression: String,
@@ -121,7 +122,7 @@ fun GlobeCategorizedMusicCollectionView(
                 contentAlignment = Alignment.BottomEnd,
             ) {
                 Image(
-                    bitmap = content.image,
+                    bitmap = content.imageBitmap,
                     contentScale = ContentScale.Crop,
                     contentDescription = null,
                     modifier = Modifier
@@ -166,7 +167,7 @@ fun PodcastCollectionView(
         },
         thumbnail = { content ->
             Image(
-                bitmap = content.image,
+                bitmap = content.imageBitmap,
                 contentScale = ContentScale.Crop,
                 contentDescription = null,
                 modifier = Modifier
@@ -205,7 +206,7 @@ fun VideoCollectionView(
         thumbnail = { content ->
             Box(contentAlignment = Alignment.BottomEnd) {
                 Image(
-                    bitmap = content.image,
+                    bitmap = content.imageBitmap,
                     contentScale = ContentScale.FillHeight,
                     contentDescription = null,
                     modifier = Modifier
@@ -277,22 +278,32 @@ private fun ContentCollectionView(
                             verticalArrangement = Arrangement.spacedBy(4.dp),
                             modifier = Modifier.width(contentWidth)
                         ) {
-                            Text(
-                                text = content.title,
-                                style = TextStyle(
-                                    fontSize = 16.sp,
-                                ),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            Text(
-                                text = content.author,
-                                style = TextStyle(
-                                    color = TextStyle.Default.color.copy(alpha = 0.5f)
-                                ),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.height(24.dp)
+                            ) {
+                                Text(
+                                    text = content.title,
+                                    style = TextStyle(
+                                        fontSize = 16.sp,
+                                    ),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.height(24.dp)
+                            ) {
+                                Text(
+                                    text = content.author,
+                                    style = TextStyle(
+                                        color = TextStyle.Default.color.copy(alpha = 0.5f)
+                                    ),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
                     }
                 }
@@ -307,14 +318,7 @@ private fun ContentCollectionView(
 fun PreviewGlobeCategorizedMusicCollectionView() {
     GlobeCategorizedMusicCollectionView(
         title = "오늘 발매 음악",
-        contentList = List(15) {
-            Content(
-                title = "LILAC",
-                author = "IU",
-                image = ImageBitmap.imageResource(id = R.drawable.img_album_exp2),
-                length = 200,
-            )
-        },
+        contentList = getTestContentList(),
         globeCategory = GlobeCategory.GLOBAL,
         onViewTitleClicked = {},
         onContentClicked = {},
@@ -331,7 +335,7 @@ fun PreviewPodcastCollectionView() {
             Content(
                 title = "김시선의 귀책사유 FLO X 윌라",
                 author = "김시선",
-                image = ImageBitmap.imageResource(id = R.drawable.img_potcast_exp),
+                imageId = R.drawable.img_potcast_exp,
                 length = 200,
             )
         },
@@ -348,7 +352,7 @@ fun PreviewVideoCollectionView() {
             Content(
                 title = "제목",
                 author = "지은이",
-                image = ImageBitmap.imageResource(id = R.drawable.img_video_exp),
+                imageId = R.drawable.img_video_exp,
                 length = 200,
             )
         },

--- a/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
@@ -1,5 +1,7 @@
 package umc.study.umc_7th.home
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -41,8 +43,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import umc.study.umc_7th.Content
+import umc.study.umc_7th.PodcastContent
 import umc.study.umc_7th.R
-import umc.study.umc_7th.getTestContentList
+import umc.study.umc_7th.VideoContent
+import umc.study.umc_7th.getTestMusicContentList
 
 enum class GlobeCategory(
     val expression: String,
@@ -311,12 +315,13 @@ private fun ContentCollectionView(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun PreviewGlobeCategorizedMusicCollectionView() {
     GlobeCategorizedMusicCollectionView(
         title = "오늘 발매 음악",
-        contentList = getTestContentList(),
+        contentList = getTestMusicContentList((1..4).random()),
         globeCategory = GlobeCategory.GLOBAL,
         onViewTitleClicked = {},
         onContentClicked = {},
@@ -330,7 +335,7 @@ fun PreviewPodcastCollectionView() {
     PodcastCollectionView(
         title = "매일 들어도 좋은 팟캐스트",
         contentList = List(15) {
-            Content(
+            PodcastContent(
                 title = "김시선의 귀책사유 FLO X 윌라",
                 author = "김시선",
                 imageId = R.drawable.img_potcast_exp,
@@ -347,7 +352,7 @@ fun PreviewVideoCollectionView() {
     VideoCollectionView(
         title = "비디오 콜렉션",
         contentList = List(15) {
-            Content(
+            VideoContent(
                 title = "제목",
                 author = "지은이",
                 imageId = R.drawable.img_video_exp,

--- a/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
@@ -29,11 +29,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/ContentCollectionView.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import umc.study.umc_7th.Content
+import umc.study.umc_7th.MusicContent
 import umc.study.umc_7th.PodcastContent
 import umc.study.umc_7th.R
 import umc.study.umc_7th.VideoContent
@@ -59,10 +60,10 @@ enum class GlobeCategory(
 @Composable
 fun GlobeCategorizedMusicCollectionView(
     title: String,
-    contentList: List<Content>,
+    contentList: List<MusicContent>,
     globeCategory: GlobeCategory,
     onViewTitleClicked: () -> Unit,
-    onContentClicked: (Content) -> Unit,
+    onContentClicked: (MusicContent) -> Unit,
     onCategoryClicked: (GlobeCategory) -> Unit,
 ) {
     ContentCollectionView(
@@ -237,11 +238,11 @@ fun VideoCollectionView(
 }
 
 @Composable
-private fun ContentCollectionView(
-    contentList: List<Content>,
+private fun <T: Content> ContentCollectionView(
+    contentList: List<T>,
     titleBar: @Composable () -> Unit, // 제목 바에 그려질 컴포저블
-    thumbnail: @Composable (Content) -> Unit, // 컨텐츠 미리보기 사진 컴포저블
-    onContentClicked: (Content) -> Unit
+    thumbnail: @Composable (T) -> Unit, // 컨텐츠 미리보기 사진 컴포저블
+    onContentClicked: (T) -> Unit
 ) {
     val density = LocalDensity.current
     var contentWidth by remember { mutableStateOf(0.dp) }

--- a/app/src/main/java/umc/study/umc_7th/home/Footer.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/Footer.kt
@@ -1,7 +1,5 @@
-package umc.study.umc_7th
+package umc.study.umc_7th.home
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -23,6 +21,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import umc.study.umc_7th.R
 
 enum class SocialContact(
     val url: String,

--- a/app/src/main/java/umc/study/umc_7th/home/HomeFragment.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/HomeFragment.kt
@@ -1,4 +1,4 @@
-package umc.study.umc_7th
+package umc.study.umc_7th.home
 
 import android.os.Build
 import android.os.Bundle
@@ -21,6 +21,12 @@ import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
+import umc.study.umc_7th.BottomNavigationBar
+import umc.study.umc_7th.Content
+import umc.study.umc_7th.NavigationDestination
+import umc.study.umc_7th.R
+import umc.study.umc_7th.album.AlbumFragment
+import umc.study.umc_7th.getTestContentList
 import java.time.LocalDate
 
 class HomeFragment : Fragment() {
@@ -32,7 +38,15 @@ class HomeFragment : Fragment() {
     ): View? {
         return inflater.inflate(R.layout.fragment_home, container, false).apply {
             findViewById<ComposeView>(R.id.composeView_home).setContent {
-                HomeScreen()
+                HomeScreen(
+                    onContentClicked = {
+                        val albumFragment = AlbumFragment()
+                        activity?.supportFragmentManager?.beginTransaction()
+                            ?.replace(R.id.fragmentContainerView_main, albumFragment)
+                            ?.addToBackStack(null)
+                            ?.commit()
+                    }
+                )
             }
         }
     }
@@ -40,7 +54,9 @@ class HomeFragment : Fragment() {
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-private fun HomeScreen() {
+private fun HomeScreen(
+    onContentClicked: (Content) -> Unit,
+) {
     // 이 스크린은 목업용 화면입니다.
     Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
         MainBanner(
@@ -50,7 +66,7 @@ private fun HomeScreen() {
                 Content(
                     title = "Butter",
                     author = "BTS",
-                    image = ImageBitmap.imageResource(id = R.drawable.img_album_exp),
+                    imageId = R.drawable.img_album_exp,
                     length = 200,
                 )
             },
@@ -63,17 +79,10 @@ private fun HomeScreen() {
         )
         GlobeCategorizedMusicCollectionView(
             title = "오늘 발매 음악",
-            contentList = List(15) {
-                Content(
-                    title = "LILAC",
-                    author = "IU",
-                    image = ImageBitmap.imageResource(id = R.drawable.img_album_exp2),
-                    length = 200,
-                )
-            },
+            contentList = getTestContentList(),
             globeCategory = GlobeCategory.GLOBAL,
             onViewTitleClicked = {},
-            onContentClicked = {},
+            onContentClicked = onContentClicked,
             onCategoryClicked = {},
         )
         PromotionImageBanner(
@@ -86,11 +95,11 @@ private fun HomeScreen() {
                 Content(
                     title = "김시선의 귀책사유 FLO X 윌라",
                     author = "김시선",
-                    image = ImageBitmap.imageResource(id = R.drawable.img_potcast_exp),
+                    imageId = R.drawable.img_potcast_exp,
                     length = 200,
                 )
             },
-            onContentClicked = {},
+            onContentClicked = onContentClicked,
         )
         VideoCollectionView(
             title = "비디오 콜렉션",
@@ -98,11 +107,11 @@ private fun HomeScreen() {
                 Content(
                     title = "제목",
                     author = "지은이",
-                    image = ImageBitmap.imageResource(id = R.drawable.img_video_exp),
+                    imageId = R.drawable.img_video_exp,
                     length = 200,
                 )
             },
-            onContentClicked = {},
+            onContentClicked = onContentClicked,
         )
         PromotionImageBanner(
             image = ImageBitmap.imageResource(id = R.drawable.discovery_banner_aos),
@@ -134,7 +143,7 @@ fun PreviewHomeScreen() {
                 currentContent = Content(
                     title = "Butter",
                     author = "BTS",
-                    image = ImageBitmap.imageResource(id = R.drawable.img_album_exp),
+                    imageId = R.drawable.img_album_exp,
                     length = 200,
                 ),
                 isPlaying = false,
@@ -142,7 +151,9 @@ fun PreviewHomeScreen() {
         }
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
-            HomeScreen()
+            HomeScreen(
+                onContentClicked = {}
+            )
         }
     }
 }

--- a/app/src/main/java/umc/study/umc_7th/home/HomeFragment.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/HomeFragment.kt
@@ -23,10 +23,13 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import umc.study.umc_7th.BottomNavigationBar
 import umc.study.umc_7th.Content
+import umc.study.umc_7th.MusicContent
 import umc.study.umc_7th.NavigationDestination
+import umc.study.umc_7th.PodcastContent
 import umc.study.umc_7th.R
+import umc.study.umc_7th.VideoContent
 import umc.study.umc_7th.album.AlbumFragment
-import umc.study.umc_7th.getTestContentList
+import umc.study.umc_7th.getTestMusicContentList
 import java.time.LocalDate
 
 class HomeFragment : Fragment() {
@@ -39,8 +42,11 @@ class HomeFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_home, container, false).apply {
             findViewById<ComposeView>(R.id.composeView_home).setContent {
                 HomeScreen(
-                    onContentClicked = {
+                    onMusicContentClicked = { content ->
                         val albumFragment = AlbumFragment()
+                        val bundle = Bundle()
+                        bundle.putSerializable("album", content.album)
+                        albumFragment.arguments = bundle
                         activity?.supportFragmentManager?.beginTransaction()
                             ?.replace(R.id.fragmentContainerView_main, albumFragment)
                             ?.addToBackStack(null)
@@ -55,23 +61,17 @@ class HomeFragment : Fragment() {
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun HomeScreen(
-    onContentClicked: (Content) -> Unit,
+    onMusicContentClicked: (MusicContent) -> Unit,
 ) {
     // 이 스크린은 목업용 화면입니다.
     Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
         MainBanner(
             title = "포근하게 덮어주는 꿈의 목소리",
             date = LocalDate.parse("2019-11-11"),
-            contentList = List(15) {
-                Content(
-                    title = "Butter",
-                    author = "BTS",
-                    imageId = R.drawable.img_album_exp,
-                    length = 200,
-                )
-            },
+            contentList = getTestMusicContentList((1..4).random()),
             textColor = Color.White,
             backgroundImage = ImageBitmap.imageResource(id = R.drawable.img_default_4_x_1),
+            onContentClicked = onMusicContentClicked,
             onVoiceSearchButtonClicked = {},
             onSubscriptionButtonClicked = {},
             onSettingButtonClicked = {},
@@ -79,10 +79,10 @@ private fun HomeScreen(
         )
         GlobeCategorizedMusicCollectionView(
             title = "오늘 발매 음악",
-            contentList = getTestContentList(),
+            contentList = getTestMusicContentList((1..4).random()),
             globeCategory = GlobeCategory.GLOBAL,
             onViewTitleClicked = {},
-            onContentClicked = onContentClicked,
+            onContentClicked = onMusicContentClicked,
             onCategoryClicked = {},
         )
         PromotionImageBanner(
@@ -92,26 +92,26 @@ private fun HomeScreen(
         PodcastCollectionView(
             title = "매일 들어도 좋은 팟캐스트",
             contentList = List(15) {
-                Content(
+                PodcastContent(
                     title = "김시선의 귀책사유 FLO X 윌라",
                     author = "김시선",
                     imageId = R.drawable.img_potcast_exp,
                     length = 200,
                 )
             },
-            onContentClicked = onContentClicked,
+            onContentClicked = { /* TODO */ },
         )
         VideoCollectionView(
             title = "비디오 콜렉션",
             contentList = List(15) {
-                Content(
+                VideoContent(
                     title = "제목",
                     author = "지은이",
                     imageId = R.drawable.img_video_exp,
                     length = 200,
                 )
             },
-            onContentClicked = onContentClicked,
+            onContentClicked = { /* TODO */ },
         )
         PromotionImageBanner(
             image = ImageBitmap.imageResource(id = R.drawable.discovery_banner_aos),
@@ -140,19 +140,14 @@ fun PreviewHomeScreen() {
                 onPlayButtonClicked = {},
                 onContentClicked = {},
                 currentDestination = NavigationDestination.HOME,
-                currentContent = Content(
-                    title = "Butter",
-                    author = "BTS",
-                    imageId = R.drawable.img_album_exp,
-                    length = 200,
-                ),
+                currentContent = getTestMusicContentList((1..4).random()).random(),
                 isPlaying = false,
             )
         }
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             HomeScreen(
-                onContentClicked = {}
+                onMusicContentClicked = {}
             )
         }
     }

--- a/app/src/main/java/umc/study/umc_7th/home/MainBanner.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/MainBanner.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
@@ -41,12 +42,13 @@ import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun MainBanner(
+fun <T: Content> MainBanner(
     title: String,
     date: LocalDate,
-    contentList: List<Content>,
+    contentList: List<T>,
     textColor: Color,
     backgroundImage: ImageBitmap,
+    onContentClicked: (T) -> Unit,
     onVoiceSearchButtonClicked: () -> Unit,
     onSubscriptionButtonClicked: () -> Unit,
     onSettingButtonClicked: () -> Unit,
@@ -135,7 +137,7 @@ fun MainBanner(
                             contentColor = textColor,
                             disabledContentColor = textColor,
                         ),
-                        onClick = { /* TODO: 기능 구현 */ },
+                        onClick = { onContentClicked(content) },
                         shape = RoundedCornerShape(8.dp),
                         contentPadding = PaddingValues(vertical = 8.dp)
                     ) {
@@ -147,7 +149,9 @@ fun MainBanner(
                             Image(
                                 bitmap = content.imageBitmap,
                                 contentDescription = null,
-                                modifier = Modifier.size(40.dp)
+                                modifier = Modifier
+                                    .size(40.dp)
+                                    .clip(RoundedCornerShape(2.dp))
                             )
                             Column(
                                 verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -173,6 +177,7 @@ fun PreviewBanner() {
         contentList = getTestMusicContentList((1..4).random()),
         textColor = Color.White,
         backgroundImage = ImageBitmap.imageResource(id = R.drawable.img_default_4_x_1),
+        onContentClicked = {},
         onVoiceSearchButtonClicked = {},
         onSubscriptionButtonClicked = {},
         onSettingButtonClicked = {},

--- a/app/src/main/java/umc/study/umc_7th/home/MainBanner.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/MainBanner.kt
@@ -1,9 +1,8 @@
-package umc.study.umc_7th
+package umc.study.umc_7th.home
 
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
@@ -35,6 +33,8 @@ import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import umc.study.umc_7th.Content
+import umc.study.umc_7th.R
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -144,7 +144,7 @@ fun MainBanner(
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             Image(
-                                bitmap = content.image,
+                                bitmap = content.imageBitmap,
                                 contentDescription = null,
                                 modifier = Modifier.size(40.dp)
                             )
@@ -173,7 +173,7 @@ fun PreviewBanner() {
             Content(
                 title = "Butter",
                 author = "BTS",
-                image = ImageBitmap.imageResource(id = R.drawable.img_album_exp),
+                imageId = R.drawable.img_album_exp,
                 length = 200,
             )
         },

--- a/app/src/main/java/umc/study/umc_7th/home/MainBanner.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/MainBanner.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import umc.study.umc_7th.Content
 import umc.study.umc_7th.R
+import umc.study.umc_7th.getTestMusicContentList
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -169,14 +170,7 @@ fun PreviewBanner() {
     MainBanner(
         title = "포근하게 덮어주는 꿈의 목소리",
         date = LocalDate.parse("2019-11-11"),
-        contentList = List(15) {
-            Content(
-                title = "Butter",
-                author = "BTS",
-                imageId = R.drawable.img_album_exp,
-                length = 200,
-            )
-        },
+        contentList = getTestMusicContentList((1..4).random()),
         textColor = Color.White,
         backgroundImage = ImageBitmap.imageResource(id = R.drawable.img_default_4_x_1),
         onVoiceSearchButtonClicked = {},

--- a/app/src/main/java/umc/study/umc_7th/home/PromotionBanner.kt
+++ b/app/src/main/java/umc/study/umc_7th/home/PromotionBanner.kt
@@ -1,4 +1,4 @@
-package umc.study.umc_7th
+package umc.study.umc_7th.home
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import umc.study.umc_7th.R
 
 @Composable
 fun PromotionImageBanner(

--- a/app/src/main/java/umc/study/umc_7th/song/ContentFrame.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/ContentFrame.kt
@@ -1,0 +1,98 @@
+package umc.study.umc_7th.song
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import umc.study.umc_7th.R
+import umc.study.umc_7th.getTestContentList
+
+@Composable
+fun ContentFrame(
+    title: String,
+    author: String,
+    cover: ImageBitmap,
+    onAuthorNameClicked: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .padding(4.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = title,
+            style = TextStyle(
+                fontWeight = FontWeight.Bold,
+                fontSize = 20.sp,
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Clip
+        )
+        Button(
+            onClick = onAuthorNameClicked,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                contentColor = Color.Black.copy(alpha = 0.5f)
+            ),
+            shape = RoundedCornerShape(4.dp),
+            contentPadding = PaddingValues(4.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = author,
+                    maxLines = 1,
+                    overflow = TextOverflow.Clip
+                )
+                Icon(
+                    painter = painterResource(id = R.drawable.btn_arrow_more),
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+        Image(
+            bitmap = cover,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .fillMaxWidth(0.6f)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewContentFrame() {
+    val content = getTestContentList().random()
+
+    ContentFrame(
+        title = content.title,
+        author = content.author,
+        cover = content.imageBitmap,
+        onAuthorNameClicked = {},
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/song/ContentFrame.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/ContentFrame.kt
@@ -1,5 +1,7 @@
 package umc.study.umc_7th.song
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,7 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import umc.study.umc_7th.R
-import umc.study.umc_7th.getTestContentList
+import umc.study.umc_7th.getTestMusicContentList
 
 @Composable
 fun ContentFrame(
@@ -84,10 +86,11 @@ fun ContentFrame(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun PreviewContentFrame() {
-    val content = getTestContentList().random()
+    val content = getTestMusicContentList((1..4).random()).random()
 
     ContentFrame(
         title = content.title,

--- a/app/src/main/java/umc/study/umc_7th/song/FooterActionBar.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/FooterActionBar.kt
@@ -1,0 +1,69 @@
+package umc.study.umc_7th.song
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import umc.study.umc_7th.R
+
+@Composable
+fun FooterActionBar(
+    onInstagramButtonClicked: () -> Unit,
+    onSimilarSongButtonClicked: () -> Unit,
+    onPlaylistButtonClicked: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .fillMaxWidth(),
+    ) {
+        IconButton(
+            onClick = onInstagramButtonClicked,
+            modifier = Modifier.size(32.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.btn_actionbar_instagram),
+                contentDescription = null,
+            )
+        }
+        IconButton(
+            onClick = onSimilarSongButtonClicked,
+            modifier = Modifier.size(32.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.btn_player_related),
+                contentDescription = null,
+            )
+        }
+        IconButton(
+            onClick = onPlaylistButtonClicked,
+            modifier = Modifier.size(32.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.btn_player_go_list),
+                contentDescription = null,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFooterActionBar() {
+    FooterActionBar(
+        onPlaylistButtonClicked = {},
+        onInstagramButtonClicked = {},
+        onSimilarSongButtonClicked = {},
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/song/LyricsView.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/LyricsView.kt
@@ -1,0 +1,56 @@
+package umc.study.umc_7th.song
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LyricsView(
+    line1: String,
+    line2: String,
+    onClicked: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .padding(4.dp)
+            .fillMaxWidth()
+    ) {
+        Button(
+            onClick = onClicked,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                contentColor = Color.Black.copy(0.5f)
+            ),
+            shape = RoundedCornerShape(4.dp)
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(text = line1)
+                Text(text = line2)
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewLyricView() {
+    LyricsView(
+        line1 = "내리는 꽃가루에",
+        line2 = "눈이 따끔해 아야",
+        onClicked = {},
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/song/PlayProgressControlPanel.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/PlayProgressControlPanel.kt
@@ -1,0 +1,195 @@
+package umc.study.umc_7th.song
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import umc.study.umc_7th.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlayProgressControlPanel(
+    length: Int,
+    playingPoint: Int,
+    isPlaying: Boolean,
+    isRepeating: Boolean,
+    isShuffling: Boolean,
+    isLiked: Boolean,
+    isBlocked: Boolean,
+    onLikeButtonClicked : (Boolean) -> Unit,
+    onBlockButtonClicked : (Boolean) -> Unit,
+    onRepeatButtonClicked : (Boolean) -> Unit,
+    onShuffleButtonClicked : (Boolean) -> Unit,
+    onPreviousButtonClicked : () -> Unit,
+    onNextButtonClicked : () -> Unit,
+    onPlayButtonClicked : (Boolean) -> Unit,
+    onPlayingPointChanged: (Int) -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(4.dp)
+    ) {
+        // 좋아요와 싫어요
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(
+                32.dp,
+                alignment = Alignment.CenterHorizontally
+            ),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            IconButton(onClick = { onLikeButtonClicked(!isLiked) }) {
+                Image(
+                    painter = painterResource(
+                        id = if (isLiked) R.drawable.ic_my_like_on
+                        else R.drawable.ic_my_like_off
+                    ),
+                    contentDescription = null,
+                )
+            }
+            IconButton(onClick = { onBlockButtonClicked(!isBlocked) }) {
+                Image(
+                    painter = painterResource(
+                        id = if (isBlocked) R.drawable.btn_player_unlike_on
+                        else R.drawable.btn_player_unlike_off
+                    ),
+                    contentDescription = null,
+                )
+            }
+        }
+        // 재생 위치 표시 및 조정
+        Column {
+            Slider(
+                value = playingPoint.toFloat(),
+                onValueChange = { onPlayingPointChanged(it.toInt()) },
+                valueRange = 0f..length.toFloat(),
+                thumb = {},
+                colors = SliderDefaults.colors(
+                    activeTrackColor = Color.Blue,
+                ),
+                modifier = Modifier.height(24.dp)
+            )
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .fillMaxWidth()
+            ) {
+                Text(
+                    text = "${"%02d".format(playingPoint / 60)}:${"%02d".format(playingPoint % 60)}",
+                    style = TextStyle(
+                        fontSize = 12.sp,
+                        color = Color.Blue,
+                    )
+                )
+                Text(
+                    text = "${"%02d".format(length / 60)}:${"%02d".format(length % 60)}",
+                    style = TextStyle(
+                        fontSize = 12.sp,
+                        color = Color.Black.copy(alpha = 0.5f)
+                    )
+                )
+            }
+        }
+        // 버튼 바
+        Row(
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            IconButton(
+                onClick = { onRepeatButtonClicked(!isRepeating) },
+                modifier = Modifier.size(48.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.nugu_btn_repeat_inactive),
+                    contentDescription = null,
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(
+                    onClick = onPreviousButtonClicked,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.nugu_btn_skip_previous_32),
+                        contentDescription = null,
+                    )
+                }
+                IconButton(
+                    onClick = { onPlayButtonClicked(!isPlaying) },
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(
+                            id = if (isPlaying) R.drawable.nugu_btn_pause_32
+                            else R.drawable.nugu_btn_play_32
+                        ),
+                        contentDescription = null,
+                    )
+                }
+                IconButton(
+                    onClick = onNextButtonClicked,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.nugu_btn_skip_next_32),
+                        contentDescription = null,
+                    )
+                }
+            }
+            IconButton(
+                onClick = { onShuffleButtonClicked(!isShuffling) },
+                modifier = Modifier.size(48.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.nugu_btn_random_inactive),
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewPlayProgressControlPanel() {
+    PlayProgressControlPanel(
+        length = 181,
+        playingPoint = 125,
+        isPlaying = true,
+        isRepeating = true,
+        isShuffling = false,
+        isLiked = true,
+        isBlocked = false,
+        onLikeButtonClicked = {},
+        onBlockButtonClicked = {},
+        onRepeatButtonClicked = {},
+        onShuffleButtonClicked = {},
+        onPreviousButtonClicked = {},
+        onNextButtonClicked = {},
+        onPlayButtonClicked = {},
+        onPlayingPointChanged = {},
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/song/SongActivity.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/SongActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,7 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import umc.study.umc_7th.Content
-import umc.study.umc_7th.getTestContentList
+import umc.study.umc_7th.getTestMusicContentList
 import umc.study.umc_7th.ui.theme.Umc_7thTheme
 
 class SongActivity: ComponentActivity() {
@@ -105,13 +106,14 @@ private fun SongScreen(
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun PreviewSongScreen() {
     Scaffold { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             SongScreen(
-                content = getTestContentList().random(),
+                content = getTestMusicContentList((1..4).random()).random(),
                 onMinimizeButtonClicked = {}
             )
         }

--- a/app/src/main/java/umc/study/umc_7th/song/SongActivity.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/SongActivity.kt
@@ -1,0 +1,115 @@
+package umc.study.umc_7th.song
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import umc.study.umc_7th.Content
+import umc.study.umc_7th.getTestContentList
+import umc.study.umc_7th.ui.theme.Umc_7thTheme
+
+class SongActivity: ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val content = intent.getSerializableExtra("content") as Content?
+
+        setContent {
+            Umc_7thTheme {
+                Scaffold { innerPadding ->
+                    Box(modifier = Modifier.padding(innerPadding)) {
+                        content?.let {
+                            SongScreen(
+                                content = it,
+                                onMinimizeButtonClicked = {
+                                    finish()
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SongScreen(
+    content: Content,
+    onMinimizeButtonClicked: () -> Unit,
+) {
+    // 이 스크린은 목업용 화면입니다.
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        TopButtonBar(
+            onSettingButtonClicked = {},
+            onEqualizerButtonClicked = {},
+            onMinimizeButtonClicked = onMinimizeButtonClicked,
+            onDetailsButtonClicked = {},
+        )
+        ContentFrame(
+            title = content.title,
+            author = content.author,
+            cover = content.imageBitmap,
+            onAuthorNameClicked = {},
+        )
+        LyricsView(
+            line1 = "내리는 꽃가루에",
+            line2 = "눈이 따끔해 아야",
+            onClicked = {},
+        )
+        PlayProgressControlPanel(
+            length = 181,
+            playingPoint = 125,
+            isPlaying = true,
+            isRepeating = true,
+            isShuffling = false,
+            isLiked = true,
+            isBlocked = false,
+            onLikeButtonClicked = {},
+            onBlockButtonClicked = {},
+            onRepeatButtonClicked = {},
+            onShuffleButtonClicked = {},
+            onPreviousButtonClicked = {},
+            onNextButtonClicked = {},
+            onPlayButtonClicked = {},
+            onPlayingPointChanged = {},
+        )
+        FooterActionBar(
+            onPlaylistButtonClicked = {},
+            onInstagramButtonClicked = {},
+            onSimilarSongButtonClicked = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun PreviewSongScreen() {
+    Scaffold { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            SongScreen(
+                content = getTestContentList().random(),
+                onMinimizeButtonClicked = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/umc/study/umc_7th/song/SongActivity.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/SongActivity.kt
@@ -1,5 +1,6 @@
 package umc.study.umc_7th.song
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -25,7 +26,10 @@ class SongActivity: ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        val content = intent.getSerializableExtra("content") as Content?
+        val content = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            intent.getSerializableExtra("content", Content::class.java)
+        else
+            intent.getSerializableExtra("content") as? Content
 
         setContent {
             Umc_7thTheme {

--- a/app/src/main/java/umc/study/umc_7th/song/TopButtonBar.kt
+++ b/app/src/main/java/umc/study/umc_7th/song/TopButtonBar.kt
@@ -1,0 +1,90 @@
+package umc.study.umc_7th.song
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import umc.study.umc_7th.R
+
+@Composable
+fun TopButtonBar(
+    onSettingButtonClicked: () -> Unit,
+    onEqualizerButtonClicked: () -> Unit,
+    onMinimizeButtonClicked: () -> Unit,
+    onDetailsButtonClicked: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth(),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = onSettingButtonClicked,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.btn_player_setting),
+                    contentDescription = null,
+                )
+            }
+            IconButton(
+                onClick = onEqualizerButtonClicked,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.btn_player_eq_off),
+                    contentDescription = null,
+                )
+            }
+        }
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            IconButton(
+                onClick = onMinimizeButtonClicked,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.nugu_btn_down),
+                    contentDescription = null,
+                )
+            }
+            IconButton(
+                onClick = onDetailsButtonClicked,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.btn_player_more),
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTopButtonBar() {
+    TopButtonBar(
+        onSettingButtonClicked = {},
+        onDetailsButtonClicked = {},
+        onEqualizerButtonClicked = {},
+        onMinimizeButtonClicked = {},
+    )
+}

--- a/app/src/main/java/umc/study/umc_7th/ui/theme/Theme.kt
+++ b/app/src/main/java/umc/study/umc_7th/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package umc.study.umc_7th.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/res/layout/fragment_album.xml
+++ b/app/src/main/res/layout/fragment_album.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+     android:layout_width="match_parent"
+     android:layout_height="match_parent">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeView_album"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# 📍Summary

> 해당 PR에 대한 내용을 요약해주세요.

SongActivity, AlbumFragment의 추가 화면 구현
프래그먼트와 액티비티 간 정보 공유 구현

# 💡PR Point

> 코드들에서 핵심 코드들을 설명해주세요.
> 또는 알게된 부분들을 공유해주세요.

Fragment의 레이아웃 안에 ComposeView 요소를 삽입하고 그것을 불러와 Compose의 진입점으로 사용하였다.
각종 Activity와 Fragment를 Compose로 제작한 뒤 폴더별로 구분해주었다.

Content 객체를 sealed 클래스로 바꾸고 그것을 상속해 다양한 유형의 콘텐츠를 표현하도록 만들었다. 특히 MusicContent 객체의 리스트를 관리하는 Album 클래스를 추가하여 앨범 시스템을 구현하였다.

음악 앱의 특성상 한 화면에 이미지를 많이 사용하여 로드가 길어지는 문제가 있었다. 이를 해결하기 위해서 ImageLoader 객체를 도입하여 이미지를 캐싱하였다.
  
# 🤔 Question

> 작업하시면서 궁금했던 질문들을 남겨주세요.

전에 사용하던 getSerializableExtra 메소드가 Deprecated 되었다. 이를 해결하기 위해서는 어떤 방식을 취해야 할까? Serializable한 객체를 넘기는 방식을 그대로 유지하되, String으로 직렬화하여 주는 방법이 있을 것이고, 아니면 Intent를 사용하지 않고 프래그먼트가 넘어갈 때마다 서버에 정보를 요청하게 할 수도 있을 것이다. 둘 중에 어떤 방법이 좋을까?
  
## 📸 ScreenShot

> 작업 내용을 스크린샷 또는 영상 형태로 올려주세요.

<div align=center>
  <img src="https://github.com/user-attachments/assets/40a88cc3-a709-4110-acfe-1ddc6c2ad89d" width="30%"/>
</div>
