### PR TITLE
[Ean/#25] 5주차 구현

### DIFF
--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -257,6 +257,17 @@
           <option name="screenY" value="2176" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q6q" />
+          <option name="id" value="q6q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-F956B" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1856" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="30" />
           <option name="brand" value="google" />
           <option name="codename" value="r11" />
@@ -311,17 +322,6 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2424" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
-          <option name="api" value="29" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="x1q" />
-          <option name="id" value="x1q" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S20" />
-          <option name="screenDensity" value="480" />
-          <option name="screenX" value="1440" />
-          <option name="screenY" value="3200" />
         </PersistentDeviceSelectionData>
       </list>
     </option>

--- a/app/src/main/java/Memo/DisplayActivity.kt
+++ b/app/src/main/java/Memo/DisplayActivity.kt
@@ -1,0 +1,79 @@
+package Memo
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+class DisplayActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Intent에서 메모 내용을 가져옴
+        val noteContent = intent.getStringExtra("noteContent") ?: ""
+
+        setContent {
+            DisplayScreen(noteContent)
+        }
+    }
+    @Composable
+    fun DisplayScreen(noteContent: String) {
+        var showDialog by remember { mutableStateOf(false) }
+
+        if(showDialog){
+            AlertDialog(
+                onDismissRequest = { showDialog = false },
+                title = { Text("이어 작성") },
+                text = { Text("이어 작성하시겠습니까?") },
+                confirmButton = {
+                    Button(onClick = {
+                        val intent = Intent(this@DisplayActivity, MainActivity::class.java).apply{
+                            putExtra("noteContent", noteContent)
+                        }
+                        startActivity(intent)
+                        showDialog = false }) {
+                        Text("네")
+                    }
+                },
+                dismissButton = {
+                    Button(onClick = {
+                        val intent = Intent(this@DisplayActivity, MainActivity::class.java).apply{
+                            putExtra("clearMemo", true)
+                        }
+                        startActivity(intent)
+                        showDialog = false }) {
+                        Text("아니오")
+                    }
+                }
+            )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Memo Content",
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+            ){
+                Button(
+                    modifier=Modifier.fillMaxWidth(),
+                    onClick ={showDialog = true}
+                ){Text(text = noteContent)}
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/Memo/MainActivity.kt
+++ b/app/src/main/java/Memo/MainActivity.kt
@@ -1,0 +1,129 @@
+package Memo
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Modifier
+
+import androidx.compose.ui.unit.sp
+
+class MainActivity : ComponentActivity() {
+
+    // 메모 내용을 저장할 전역 변수
+    private var savedNote = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            NoteApp()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // onResume에서 저장된 내용이 있다면 복원
+        if (savedNote.isNotEmpty()) {
+            contentState.value = savedNote
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // 현재 메모 내용을 전역 변수에 저장
+        savedNote = contentState.value
+    }
+
+    override fun onRestart() {
+        super.onRestart()
+        // 다시 작성 여부를 묻는 다이얼로그 띄우기
+        showDialogState.value = true
+
+    }
+
+    private val contentState = mutableStateOf("")
+    private val showDialogState = mutableStateOf(false)
+
+    @Composable
+    fun NoteApp() {
+        if (showDialogState.value) {
+            RestartDialog()
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            TextField(
+                value = contentState.value,
+                onValueChange = { contentState.value = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(400.dp),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = {
+
+                val intent = Intent(this@MainActivity, DisplayActivity::class.java).apply {
+                    putExtra("noteContent", contentState.value)
+                }
+                startActivity(intent)}
+            ) {
+                Text("확인 화면으로 이동")
+            }
+        }
+    }
+
+    @Composable
+    fun RestartDialog() {
+        AlertDialog(
+            onDismissRequest = { showDialogState.value = false },
+            title = { Text("다시 작성") },
+            text = { Text("이전 메모를 다시 작성하시겠습니까?") },
+            confirmButton = {
+                Button(onClick = {
+                    savedNote = ""
+                    contentState.value = ""
+                    showDialogState.value = false
+                }) {
+                    Text("아니오")
+                }
+            },
+            dismissButton = {
+                Button(onClick = { showDialogState.value = false }) {
+                    Text("예")
+                }
+            }
+        )
+    }
+}
+
+
+
+

--- a/app/src/main/java/umc/study/umc_7th/MiniPlayer.kt
+++ b/app/src/main/java/umc/study/umc_7th/MiniPlayer.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,8 +30,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.material3.Slider
 
+
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.P)
 @Composable
 fun MiniPlayer(
@@ -41,63 +45,84 @@ fun MiniPlayer(
     musicQueueClick: () -> Unit,
     toSongActivity: (Content) -> Unit,
 ){
+    Column {
+        val currentPosition by viewModel.currentPosition.observeAsState(0f)
+        val duration by viewModel.duration.observeAsState(1f)
 
+        val progress = currentPosition / duration
 
-    Box(modifier = Modifier.clickable {toSongActivity(content) }
-    )
-    {
-        Row(
-            modifier = Modifier.background(color = Color.White)
-                .fillMaxWidth()
-                .padding(horizontal = 15.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(120.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ){
-            Column(
-                verticalArrangement = Arrangement.spacedBy(1.dp)
-            ){
-                Text(text = content.title,
-                    fontSize = 18.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis)
-                Text(
-                    text = content.author,
-                    fontSize = 15.sp,
-                    style = TextStyle(
-                        color = TextStyle.Default.color.copy(alpha = 0.5f)
-                    ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+        Slider(
+            value = progress,
+            onValueChange = { newProgress ->
+                viewModel.updatePosition(newProgress * duration)
+            },
+            modifier = Modifier
+                .fillMaxWidth().height(3.dp),
+            thumb = {},
+        )
+        Box(modifier = Modifier.clickable {toSongActivity(content) }
+        )
+        {
             Row(
-                horizontalArrangement = Arrangement.SpaceBetween
-            ){  val played by viewModel.played.observeAsState(true)
-                Icon(painter = painterResource(id = R.drawable.btn_miniplayer_previous),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(50.dp)
-                        .clickable { beforeSongPlayButtonClick() })
-                Icon(painter = painterResource(id = if(played) R.drawable.btn_miniplay_pause
-                else R.drawable.btn_miniplayer_play),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(50.dp)
-                        .clickable { viewModel.togglePlayed()
-                        playSongButtonClick()})
-                Icon(painter = painterResource(id = R.drawable.btn_miniplayer_next),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(50.dp)
-                        .clickable { nextSongPlayButtonClick() })
-                Icon(painter = painterResource(id = R.drawable.btn_miniplayer_go_list),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(50.dp)
-                        .clickable { musicQueueClick() })
+                modifier = Modifier
+                    .background(color = Color.White)
+                    .fillMaxWidth()
+                    .padding(horizontal = 15.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(120.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ){
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(1.dp)
+                ){
+                    Text(text = content.title,
+                        fontSize = 18.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis)
+                    Text(
+                        text = content.author,
+                        fontSize = 15.sp,
+                        style = TextStyle(
+                            color = TextStyle.Default.color.copy(alpha = 0.5f)
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ){  val played by viewModel.played.observeAsState(true)
+                    Icon(painter = painterResource(id = R.drawable.btn_miniplayer_previous),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(50.dp)
+                            .clickable { beforeSongPlayButtonClick() })
+                    Icon(painter = painterResource(id = if(played) R.drawable.btn_miniplay_pause
+                    else R.drawable.btn_miniplayer_play),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clickable {
+                                viewModel.togglePlayed()
+                                playSongButtonClick()
+                            })
+                    Icon(painter = painterResource(id = R.drawable.btn_miniplayer_next),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(50.dp)
+                            .clickable { nextSongPlayButtonClick() })
+                    Icon(painter = painterResource(id = R.drawable.btn_miniplayer_go_list),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(45.dp)
+                            .clickable { musicQueueClick() })
+                }
             }
         }
     }
+
+
+
 
 }
 

--- a/app/src/main/java/umc/study/umc_7th/PlayProgressBar.kt
+++ b/app/src/main/java/umc/study/umc_7th/PlayProgressBar.kt
@@ -46,14 +46,14 @@ import kotlinx.coroutines.delay
 
     var progress by remember { mutableStateOf(0f) }
 
-    LaunchedEffect(played){
-        if(played){
-            while ( played && currentPosition < duration){
-                delay(1000L)
-                viewModel.updatePosition(currentPosition+1f)
-            }
-        }
-    }
+//    LaunchedEffect(played){
+//        if(played){
+//            while ( played && currentPosition < duration){
+//                delay(1000L)
+//                viewModel.updatePosition(currentPosition+1f)
+//            }
+//        }
+//    }
     progress = currentPosition / duration
     Slider(
         value = progress,
@@ -101,7 +101,9 @@ import kotlinx.coroutines.delay
             modifier = Modifier
                 .size(65.dp)
                 .padding(10.dp)
-                .clickable { beforeSongPlayClick() }
+                .clickable { beforeSongPlayClick()
+                }
+
         )
 
         Icon(

--- a/app/src/main/java/umc/study/umc_7th/ViewModel.kt
+++ b/app/src/main/java/umc/study/umc_7th/ViewModel.kt
@@ -5,6 +5,10 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 open class SongViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -39,14 +43,34 @@ open class SongViewModel(application: Application) : AndroidViewModel(applicatio
     private val _shuffle = MutableLiveData(false)
     open val shuffle : LiveData<Boolean> = _shuffle
 
-
+    private var playbackJob : Job? = null
 
     open fun toggleReplay() {
         _replay.value = _replay.value != true
     }
     open fun togglePlayed() {
         _played.value = _played.value != true
+
+        if (_played.value == true) {
+            startPlayback()
+        }else {
+            stopPlayedback()
+        }
     }
+
+    private fun startPlayback(){
+        playbackJob?.cancel()
+        playbackJob = viewModelScope.launch {
+            while (_played.value == true && _currentPosition.value!! < _duration.value!!){
+                delay(1000L)
+                _currentPosition.value = _currentPosition.value!! + 1f
+            }
+        }
+    }
+    private fun stopPlayedback(){
+        playbackJob?.cancel()
+    }
+
     open fun toggleShuffle() {
         _shuffle.value = _shuffle.value != true
     }
@@ -56,6 +80,11 @@ open class SongViewModel(application: Application) : AndroidViewModel(applicatio
     fun setDuration(duration: Float){
         _duration.value = duration
     }
+    fun resetProgress(){ // 그 .. beforeSongPlayClick() 에 넣어줄 것
+        _currentPosition.value = 0f
+    }
+
+
 
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "umc_7th"
 include(":app")
+


### PR DESCRIPTION
# 📍Summary

> 해당 PR에 대한 내용을 요약해주세요.

MainActivity에서의 progressBar와 SongActivity에서의 progressBar를 동기화 했음. 


# 💡PR Point

> 코드들에서 핵심 코드들을 설명해주세요.
> 또는 알게된 부분들을 공유해주세요.
  
뷰모델을 활용해서 두 액티비티간의 progressBar의 상태를 관리할 수 있었다. 
처음에는 한 곳에서 코루틴을 적용하여? 시도했으나 동기화가 제대로 되지 않는 문제점을 발견했고, 원래 songActivity 및 MainActivity의 miniplayer 재생 버튼을 관리하던 뷰 모델에 progressBar를 관리하도록 해주어 문제를 해결하였다. 

# 🤔 Question

> 작업하시면서 궁금했던 질문들을 남겨주세요.
  
메모장 어플을 온전히 생명주기를 통해 구현하기엔 어려움이 있는데, 다른 분들은 어떻게 하셨는지.. 뭔가 허울 뿐인 코드가 만들어진 느낌입니다. 

## 📸 ScreenShot

> 작업 내용을 스크린샷 또는 영상 형태로 올려주세요.

![image](https://github.com/user-attachments/assets/a196d03f-8118-4326-8699-70bae26bc80f)
![image](https://github.com/user-attachments/assets/a151e74d-7a33-428a-a77c-69302eb685d9)
![image](https://github.com/user-attachments/assets/18c6076a-0069-47d7-b711-253d65e41092)
![image](https://github.com/user-attachments/assets/4ba47650-2639-406b-a3f8-1f5645962fcb)

