### PR TITLE
[totoro/#57] 10주차 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -9,11 +12,15 @@ plugins {
     id("com.google.devtools.ksp")
 }
 
+val localProperties = Properties()
+localProperties.load(FileInputStream(rootProject.file("local.properties")))
+
 android {
     namespace = "umc.study.umc_7th"
     compileSdk = 35
 
     defaultConfig {
+        manifestPlaceholders += mapOf()
         applicationId = "umc.study.umc_7th"
         minSdk = 26
         targetSdk = 34
@@ -25,7 +32,10 @@ android {
             useSupportLibrary = true
         }
 
-        buildConfigField("String", "SERVER_URL", "\"http://10.0.2.2:8080\"")
+        buildConfigField("String", "SERVER_URL", "\"${localProperties.getProperty("SERVER_URL")}\"")
+        buildConfigField("String", "KAKAO_OAUTH_KEY", "\"${localProperties.getProperty("KAKAO_OAUTH_NATIVE_APP_KEY")}\"")
+
+        manifestPlaceholders["NATIVE_APP_KEY"] = localProperties.getProperty("KAKAO_OAUTH_NATIVE_APP_KEY")
     }
 
     buildTypes {
@@ -137,4 +147,7 @@ dependencies {
 
     // Splash
     implementation(libs.androidx.core.splashscreen)
+
+    // 카카오 로그인 API 모듈
+    implementation(libs.v2.user)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth" android:scheme="kakao${NATIVE_APP_KEY}" />
+            </intent-filter>
+        </activity>
         <service
             android:name=".service.ContentPlayerService"
             android:enabled="true"

--- a/app/src/main/java/umc/study/umc_7th/FloApplication.kt
+++ b/app/src/main/java/umc/study/umc_7th/FloApplication.kt
@@ -1,7 +1,9 @@
 package umc.study.umc_7th
 
 import android.app.Application
+import android.util.Log
 import com.kakao.sdk.common.KakaoSdk
+import com.kakao.sdk.common.util.Utility
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
@@ -9,5 +11,7 @@ class FloApplication: Application() {
     override fun onCreate() {
         super.onCreate()
         KakaoSdk.init(this, BuildConfig.KAKAO_OAUTH_KEY)
+
+        // Log.d("Flo", "hash key: ${Utility.getKeyHash(this)}")
     }
 }

--- a/app/src/main/java/umc/study/umc_7th/FloApplication.kt
+++ b/app/src/main/java/umc/study/umc_7th/FloApplication.kt
@@ -1,11 +1,13 @@
 package umc.study.umc_7th
 
 import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
-import umc.study.umc_7th.service.ServiceHandler
-import javax.inject.Inject
 
 @HiltAndroidApp
 class FloApplication: Application() {
-    // empty
+    override fun onCreate() {
+        super.onCreate()
+        KakaoSdk.init(this, BuildConfig.KAKAO_OAUTH_KEY)
+    }
 }

--- a/app/src/main/java/umc/study/umc_7th/data/AuthRepository.kt
+++ b/app/src/main/java/umc/study/umc_7th/data/AuthRepository.kt
@@ -1,14 +1,29 @@
 package umc.study.umc_7th.data;
 
-import android.util.Log
+import umc.study.umc_7th.data.network.KakaoOAuthServer
 import umc.study.umc_7th.data.network.Server
 import javax.inject.Inject
 
 class AuthRepository @Inject constructor(
     private val server: Server,
+    private val kakaoOAuthServer: KakaoOAuthServer,
 ) {
     suspend fun signUp(email: String, password: String) = server.signUp(email, password)
     suspend fun login(email: String, password: String) = server.login(email, password)
+    suspend fun loginWithKakao() {
+        val token = kakaoOAuthServer.login() ?: throw Exception("카카오 로그인 실패")
+        val email = "${token.substring(0, 20)}@kakao.com"
+        val password = token.substring(0, 20)
+        try {
+            server.signUp(email, password)
+        }
+        catch (e: Exception) {
+            //empty
+        }
+        finally {
+            server.login(email, password)
+        }
+    }
     fun logout() = server.logout()
     suspend fun getMyProfile() = server.getMyProfile()
 }

--- a/app/src/main/java/umc/study/umc_7th/data/network/KakaoOAuthServer.kt
+++ b/app/src/main/java/umc/study/umc_7th/data/network/KakaoOAuthServer.kt
@@ -1,0 +1,27 @@
+package umc.study.umc_7th.data.network
+
+import android.content.Context
+import android.util.Log
+import com.kakao.sdk.user.Constants.TAG
+import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+class KakaoOAuthServer @Inject constructor(@ApplicationContext val context: Context) {
+    suspend fun login(): String? = suspendCancellableCoroutine { continuation ->
+        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+            when {
+                error != null -> {
+                    Log.e(TAG, "로그인 실패", error)
+                    continuation.resume(null)
+                }
+                token != null -> {
+                    Log.i(TAG, "로그인 성공 ${token.accessToken}")
+                    continuation.resume(token.accessToken)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/umc/study/umc_7th/di/KakaoOAuthServerModule.kt
+++ b/app/src/main/java/umc/study/umc_7th/di/KakaoOAuthServerModule.kt
@@ -1,23 +1,22 @@
 package umc.study.umc_7th.di
 
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import umc.study.umc_7th.data.AuthRepository
 import umc.study.umc_7th.data.network.KakaoOAuthServer
-import umc.study.umc_7th.data.network.Server
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object AuthRepositoryModule {
+object KakaoOAuthServerModule {
     @Provides
     @Singleton
-    fun provideAuthRepository(
-        server: Server,
-        kakaoOAuthServer: KakaoOAuthServer,
-    ): AuthRepository {
-        return AuthRepository(server, kakaoOAuthServer)
+    fun provideKakaoOAuthServer(
+        @ApplicationContext context: Context
+    ): KakaoOAuthServer {
+        return KakaoOAuthServer(context)
     }
 }

--- a/app/src/main/java/umc/study/umc_7th/ui/login/LoginActivity.kt
+++ b/app/src/main/java/umc/study/umc_7th/ui/login/LoginActivity.kt
@@ -78,11 +78,7 @@ class LoginActivity : ComponentActivity() {
                 viewModel.login(
                     email = "$id@$domain",
                     password = password,
-                    onSuccess = {
-                        val intent = Intent(this, MainActivity::class.java)
-                        startActivity(intent)
-                        finish()
-                    },
+                    onSuccess = { onLoginSuccess() },
                     onRejected = {
                         snackBarHost.currentSnackbarData?.dismiss()
                         snackBarHost.showSnackbar(
@@ -97,7 +93,19 @@ class LoginActivity : ComponentActivity() {
                 val intent = Intent(this, SignUpActivity::class.java)
                 startActivity(intent)
             },
+            onOAuthLoginClicked = {
+                if (it == OAuthProvider.KAKAO) viewModel.loginWithKakao(
+                    onSuccess = { onLoginSuccess() },
+                    onFailed = { /* TODO */ },
+                )
+            }
         )
+    }
+
+    private fun onLoginSuccess() {
+        val intent = Intent(this, MainActivity::class.java)
+        startActivity(intent)
+        finish()
     }
 }
 
@@ -111,6 +119,7 @@ fun LoginScreen(
     onPasswordChanged: (String) -> Unit,
     onLoginClicked: () -> Unit,
     onSignUpClicked: () -> Unit,
+    onOAuthLoginClicked: (OAuthProvider) -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.SpaceAround,
@@ -133,7 +142,7 @@ fun LoginScreen(
                 onForgotPasswordClicked = { /* TODO */ },
             )
             OtherLoginOptionViewer(
-                onOAuthLoginClicked = { /* TODO */ },
+                onOAuthLoginClicked = onOAuthLoginClicked,
                 onSktIdLoginClicked = { /* TODO */ },
                 onPhoneNumberLoginClicked = { /* TODO */ },
             )
@@ -156,6 +165,7 @@ fun PreviewLoginScreen() {
                     onPasswordChanged = {},
                     onLoginClicked = {},
                     onSignUpClicked = {},
+                    onOAuthLoginClicked = {},
                 )
             }
         }

--- a/app/src/main/java/umc/study/umc_7th/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/umc/study/umc_7th/ui/login/LoginViewModel.kt
@@ -45,4 +45,21 @@ class LoginViewModel @Inject constructor(
             }
         }
     }
+
+    fun loginWithKakao(
+        onSuccess: suspend (User) -> Unit,
+        onFailed: suspend () -> Unit,
+    ) {
+        viewModelScope.launch {
+            try {
+                authRepository.loginWithKakao()
+                val user = authRepository.getMyProfile()
+                onSuccess(user)
+            }
+            catch (e: Exception) {
+                e.printStackTrace()
+                onFailed()
+            }
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ navigationUiKtxVersion = "2.8.4"
 okhttp = "5.0.0-alpha.2"
 retrofit = "2.9.0"
 roomRuntime = "2.6.1"
+v2User = "2.20.6"
 workRuntimeKtx = "2.10.0"
 jetbrainsKotlinJvm = "2.0.21"
 
@@ -118,6 +119,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "constraintlayoutCompose" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "v2User" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/mock/build.gradle.kts
+++ b/mock/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.classpath.Instrumented.systemProperty
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -8,6 +9,13 @@ plugins {
 
 val localProperties = Properties()
 localProperties.load(FileInputStream(rootProject.file("local.properties")))
+
+listOf(
+    "KAKAO_OAUTH_REST_API_KEY",
+    "SERVER_URL"
+).forEach { key ->
+    systemProperty(key, localProperties.getProperty(key))
+}
 
 dependencies {
     implementation(libs.ktor.server.core)
@@ -25,8 +33,6 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
     implementation(libs.java.jwt)
-
-    implementation(libs.dotenv.kotlin)
 
     implementation(libs.logback.classic)
 }

--- a/mock/build.gradle.kts
+++ b/mock/build.gradle.kts
@@ -1,7 +1,13 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     kotlin("plugin.serialization") version "2.0.21"
     kotlin("jvm")
 }
+
+val localProperties = Properties()
+localProperties.load(FileInputStream(rootProject.file("local.properties")))
 
 dependencies {
     implementation(libs.ktor.server.core)

--- a/mock/src/main/java/com/example/mock/Responses.kt
+++ b/mock/src/main/java/com/example/mock/Responses.kt
@@ -93,51 +93,7 @@ data class LikeResponse(
 )
 
 @Serializable
-data class JoinRequest(
-    val name: String,
-    val email: String,
-    val password: String,
-)
-
-@Serializable
-data class JoinResponse(
-    val isSuccess: Boolean,
-    val code: String,
-    val message: String,
-    val result: JoinResult
-)
-
-@Serializable
-data class JoinResult(
-    val memberId: Int,
-    @Serializable(with = LocalDateTimeSerializer::class) val createdAt: LocalDateTime,
-    @Serializable(with = LocalDateTimeSerializer::class) val updatedAt: LocalDateTime,
-)
-
-@Serializable
 data class LoginRequest(
     val email: String,
     val password: String,
-)
-
-@Serializable
-data class LoginResponse(
-    val isSuccess: Boolean,
-    val code: String,
-    val message: String,
-    val result: LoginResult,
-)
-
-@Serializable
-data class LoginResult(
-    val memberId: Int,
-    val accessToken: String,
-)
-
-@Serializable
-data class TokenTestResponse(
-    val isSuccess: Boolean,
-    val code: String,
-    val message: String,
-    val result: String,
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = java.net.URI("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
 


### PR DESCRIPTION
# 📍Summary

> 해당 PR에 대한 내용을 요약해주세요.

모의 카카오 로그인 구현

# 💡PR Point

> 코드들에서 핵심 코드들을 설명해주세요.
> 또는 알게된 부분들을 공유해주세요.
  
### 카카오 로그인
목업 서버를 이용해서 카카오 로그인을 구현하는 것을 시도하는 중이다. 카카오 디벨롭먼트 서비스에 가입하고 앱을 등록하는 절차는 완료하였고, 안드로이드 로직에서는 간단히 SDK를 설치하면 대부분이 해결되지만, 서버의 기능 구현이 문제다.

일단은 서버에서 유저의 카카오 로그인을 연동하는 기능은 구현하지 않았다. 다만, 안드로이드에서 카카오 인증 서버를 통해 토큰을 발급받는 절차를 통해서 가상의 이메일과 비밀번호를 만들어 서버에 원래 존재하던 가입 절차에 이용하도록 구현하였다.

# 🤔 Question

> 작업하시면서 궁금했던 질문들을 남겨주세요.
  
카카오 로그인 인증 방식이 웹이랑은 많이 달랐던 것 같다. 하지만 안드로이드가 더욱 간단한 로직을 가지고 있는 것 같다. 이런 로직을 웹에도 적용할 수 있지 않을까? 안 된다면 왜 안될까?

## 📸 ScreenShot

> 작업 내용을 스크린샷 또는 영상 형태로 올려주세요.

![animation](https://github.com/user-attachments/assets/4afdd5fa-8414-4d01-a0f7-f2236abb3ada)